### PR TITLE
Map non-default named exports to the correct file

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -1,4 +1,12 @@
 export default function ({types: t}) {
+	const namespace = 'react-router/lib'
+	const importMap = {
+		createRoutes: 'RouteUtils',
+		locationShape: 'PropTypes',
+		routerShape: 'PropTypes',
+		formatPattern: 'PatternUtils'
+	}
+
 	const canReplace = ({ specifiers }) => {
 		return specifiers.length > 0 && specifiers.every((specifier) => {
 			return t.isImportSpecifier(specifier)
@@ -8,9 +16,18 @@ export default function ({types: t}) {
 
 	const replace = (specifiers) => {
 		return specifiers.map(({local, imported}) => {
+			const mapped = importMap[imported.name]
+
+			if (typeof mapped !== 'undefined') {
+				return t.importDeclaration(
+					[t.importSpecifier(local, imported)],
+					t.stringLiteral(`${namespace}/${mapped}`)
+				);
+			}
+
 			return t.importDeclaration(
-				[t.importDefaultSpecifier(t.identifier(local.name))],
-				t.stringLiteral(`react-router/lib/${imported.name}`)
+				[t.importDefaultSpecifier(local)],
+				t.stringLiteral(`${namespace}/${imported.name}`)
 			);
 		});
 	};

--- a/test/fixtures/mapped-members/actual.js
+++ b/test/fixtures/mapped-members/actual.js
@@ -1,0 +1,2 @@
+import { createRoutes, locationShape, routerShape } from 'react-router';
+import { formatPattern as format } from 'react-router';

--- a/test/fixtures/mapped-members/expected.js
+++ b/test/fixtures/mapped-members/expected.js
@@ -1,0 +1,4 @@
+import { createRoutes } from 'react-router/lib/RouteUtils';
+import { locationShape } from 'react-router/lib/PropTypes';
+import { routerShape } from 'react-router/lib/PropTypes';
+import { formatPattern as format } from 'react-router/lib/PatternUtils';


### PR DESCRIPTION
React Router (v2-3) is re-exporting a few non-default named exports, which makes the current transformation map some imports to non-existent modules.

Eg.
```js
import { Router, createRoutes } from 'react-router' // Valid imports
```
Gets transformed to:
```js
import Router from 'react-router/lib/Router'
import createRoutes from 'react-router/lib/createRoutes' // Invalid import, file doesn't exist
```

This PR aims to fix this by comparing the import identifier to an "import map". If an identifier matches a value in this map, it gets transformed to an `importSpecifier` that import the mapped module instead.

See the added fixtures for all the cases, but here's the gist of the previous example:
```js
import { Router, createRoutes } from 'react-router'
```
Gets transformed to:
```js
import Router from 'react-router/lib/Router'
import { createRoutes } from 'react-router/lib/RouteUtils'
```

The transformation is still a bit naive, because it doesn't combine multiple importSpecifier's from the same importDeclaration (see PropTypes), but I'm not sure if that actually has any real impact on performance or resulting size after bundling/transpiling.